### PR TITLE
typo on git remote to view the remotes

### DIFF
--- a/intro-to-git-and-github/PITCHME.md
+++ b/intro-to-git-and-github/PITCHME.md
@@ -121,7 +121,7 @@ their local <--> their github remote <--> my github clone <--> my local
 ```sh
 $ git add remote origin https://github.com/iotinafrica/material.git
 [git add, commit...]
-$ git remotes
+$ git remote -v
 ```
 Note:
 Works even without collaboration. Or you can grant someone perms to push to your repo. Or use the pull-request model

--- a/intro-to-git-and-github/PITCHME.md
+++ b/intro-to-git-and-github/PITCHME.md
@@ -1,4 +1,4 @@
-## Git and GutHub
+## Git and GitHub
 ##### Global Code | 2018
 ![Git and Github](/assets/img/git-910x380.png)
 Note:
@@ -127,7 +127,7 @@ Note:
 Works even without collaboration. Or you can grant someone perms to push to your repo. Or use the pull-request model
 
 +++
-##Using GitHub
+## Using GitHub
 * https://www.github.com
   * create an account
   * create a new repository
@@ -165,6 +165,8 @@ If we're working in a team
 +++
 ## Forking with github
 Try it!
-* Fork iotinafrica/2018
-* Add your github userid to `classlist`
+* Fork `glblcd/ClassBook2018`
+* Each site will have a sub-directory
+* Add your github userid to a new line in `<org>/classlist`
+* Upload your photo to `<org>/<username>.jpg` (keep resolution / size low)
 * Create a "pull request" for me to merge your change


### PR DESCRIPTION
git remotes doesn't work, checked on linux and windows, replaced with git remote -v which shows the names and urls/paths